### PR TITLE
fix: Avoid using online normalization for MetaData.create_all.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sqlalchemy-declarative-extensions"
-version = "0.5.2"
+version = "0.5.3"
 description = "Library to declare additional kinds of objects not natively supported by SqlAlchemy/Alembic."
 
 authors = ["Dan Cardin <ddcardin@gmail.com>"]

--- a/src/sqlalchemy_declarative_extensions/view/base.py
+++ b/src/sqlalchemy_declarative_extensions/view/base.py
@@ -168,12 +168,12 @@ class View:
             )
         )
 
-    def render_definition(self, conn: Connection):
+    def render_definition(self, conn: Connection, using_connection: bool = True):
         dialect = conn.engine.dialect
 
         compiled_definition = self.compile_definition(dialect)
 
-        if dialect.name == "postgresql":
+        if using_connection and dialect.name == "postgresql":
             from sqlalchemy_declarative_extensions.dialects import get_view
 
             with conn.begin_nested() as trans:
@@ -231,7 +231,9 @@ class View:
             result.append(query)
         return result
 
-    def normalize(self, conn: Connection, metadata: MetaData) -> View:
+    def normalize(
+        self, conn: Connection, metadata: MetaData, using_connection: bool = True
+    ) -> View:
         constraints = None
         if self.constraints:
             constraints = [
@@ -240,7 +242,9 @@ class View:
             ]
 
         return replace(
-            self, definition=self.render_definition(conn), constraints=constraints
+            self,
+            definition=self.render_definition(conn, using_connection=using_connection),
+            constraints=constraints,
         )
 
     def to_sql_create(self, dialect: Dialect) -> list[str]:

--- a/src/sqlalchemy_declarative_extensions/view/compare.py
+++ b/src/sqlalchemy_declarative_extensions/view/compare.py
@@ -48,7 +48,10 @@ Operation = Union[CreateViewOp, UpdateViewOp, DropViewOp]
 
 
 def compare_views(
-    connection: Connection, views: Views, metadata: MetaData
+    connection: Connection,
+    views: Views,
+    metadata: MetaData,
+    normalize_with_connection: bool = True,
 ) -> list[Operation]:
     result: list[Operation] = []
 
@@ -70,13 +73,21 @@ def compare_views(
 
         view_created = view_name in new_view_names
 
-        normalized_view = view.normalize(connection, metadata)
+        normalized_view = view.normalize(
+            connection, metadata, using_connection=normalize_with_connection
+        )
 
         if view_created:
             result.append(CreateViewOp(normalized_view))
         else:
             existing_view = existing_views_by_name[view_name]
-            normalized_existing_view = existing_view.normalize(connection, metadata)
+            normalized_existing_view = (
+                existing_view.normalize(
+                    connection, metadata, using_connection=normalize_with_connection
+                )
+                if normalize_with_connection
+                else existing_view
+            )
 
             if normalized_existing_view != normalized_view:
                 result.append(UpdateViewOp(normalized_existing_view, normalized_view))

--- a/src/sqlalchemy_declarative_extensions/view/ddl.py
+++ b/src/sqlalchemy_declarative_extensions/view/ddl.py
@@ -7,7 +7,9 @@ from sqlalchemy_declarative_extensions.view.compare import compare_views
 
 def view_ddl(views: Views):
     def after_create(metadata: MetaData, connection: Connection, **_):
-        result = compare_views(connection, views, metadata)
+        result = compare_views(
+            connection, views, metadata, normalize_with_connection=False
+        )
         for op in result:
             for command in op.to_sql(connection.dialect):
                 connection.execute(text(command))


### PR DESCRIPTION
The assumption is generally that with MetaData.create_all, it's being used to create objects from an empty database, and thus, there's less/little point in doing live/connection based normalization; since there wont be an existing view to compare against.

In particular, this change fixes the case where a view (A) dependent on another view (B) are both being created in the same comparison pass (i.e. during MetaData.create_all), and the comparison for view A tries to create itself in order to get a normalized view, only to realize that view B doesn't exist.