### PR TITLE
chore: Remove support for 3.7.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,12 @@ import pytest
 from pytest_mock_resources import MysqlConfig, PostgresConfig, create_postgres_fixture
 from pytest_mock_resources.container.base import get_container
 
+# isort: split
+# XXX: Deal with python 3.8-specific reload issue due to the `sys.modules` hack below.
+import pydantic
+
+assert pydantic
+
 pytest_plugins = "pytester"
 
 


### PR DESCRIPTION
Dependencies of the library are beginning to require 3.8 or 3.9 or higher, and it will just become more of a problem. For now, we're okay to sunset just 3.8.