### PR TITLE
fix: Support `ignore` option for functions.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sqlalchemy-declarative-extensions"
-version = "0.7.2"
+version = "0.8.0"
 authors = ["Dan Cardin <ddcardin@gmail.com>"]
 
 description = "Library to declare additional kinds of objects not natively supported by SQLAlchemy/Alembic."
@@ -96,7 +96,8 @@ filterwarnings = [
   'error',
   'ignore:invalid escape sequence.*',
   'ignore:distutils Version classes are deprecated. Use packaging.version instead.:DeprecationWarning',
-  'ignore:_SixMetaPathImporter.find_spec.*:ImportWarning'
+  'ignore:_SixMetaPathImporter.find_spec.*:ImportWarning',
+  'ignore:`ignore_views` is deprecated, use `ignore` instead:DeprecationWarning',
 ]
 pytester_example_dir = "tests/examples"
 markers = [

--- a/src/sqlalchemy_declarative_extensions/dialects/postgresql/query.py
+++ b/src/sqlalchemy_declarative_extensions/dialects/postgresql/query.py
@@ -153,7 +153,7 @@ def get_view_postgresql(connection: Connection, name: str, schema: str = "public
     )
 
 
-def get_functions_postgresql(connection: Connection):
+def get_functions_postgresql(connection: Connection) -> list[Function]:
     functions = []
     for f in connection.execute(functions_query).fetchall():
         function = Function(

--- a/src/sqlalchemy_declarative_extensions/function/base.py
+++ b/src/sqlalchemy_declarative_extensions/function/base.py
@@ -56,8 +56,16 @@ class Function:
 
 @dataclass
 class Functions:
+    """The collection of functions and associated options comparisons.
+
+    Note: `ignore` option accepts a sequence of strings. Each string is individually
+        interpreted as a "glob". This means a string like "foo.*" would ignore all views
+        contained within the schema "foo".
+    """
+
     functions: list[Function] = field(default_factory=list)
 
+    ignore: list[str] = field(default_factory=list)
     ignore_unspecified: bool = False
 
     @classmethod

--- a/src/sqlalchemy_declarative_extensions/sqlalchemy.py
+++ b/src/sqlalchemy_declarative_extensions/sqlalchemy.py
@@ -1,6 +1,11 @@
+from __future__ import annotations
+
+from typing import Callable, TypeVar
+
 import sqlalchemy
 from sqlalchemy import MetaData
 from sqlalchemy.engine import Connection
+from typing_extensions import Concatenate, ParamSpec
 
 from sqlalchemy_declarative_extensions.typing import Protocol
 
@@ -11,7 +16,16 @@ class HasMetaData(Protocol):
     metadata: MetaData
 
 
-def dialect_dispatch(postgresql=None, sqlite=None, mysql=None, snowflake=None):
+T = TypeVar("T")
+P = ParamSpec("P")
+
+
+def dialect_dispatch(
+    postgresql: Callable[Concatenate[Connection, P], T] | None = None,
+    sqlite: Callable[Concatenate[Connection, P], T] | None = None,
+    mysql: Callable[Concatenate[Connection, P], T] | None = None,
+    snowflake: Callable[Concatenate[Connection, P], T] | None = None,
+) -> Callable[Concatenate[Connection, P], T]:
     dispatchers = {
         "postgresql": postgresql,
         "sqlite": sqlite,
@@ -19,7 +33,7 @@ def dialect_dispatch(postgresql=None, sqlite=None, mysql=None, snowflake=None):
         "snowflake": snowflake,
     }
 
-    def dispatch(connection: Connection, *args, **kwargs):
+    def dispatch(connection: Connection, *args: P.args, **kwargs: P.kwargs) -> T:
         dialect_name = connection.dialect.name
         if dialect_name == "pmrsqlite":
             dialect_name = "sqlite"

--- a/src/sqlalchemy_declarative_extensions/view/base.py
+++ b/src/sqlalchemy_declarative_extensions/view/base.py
@@ -190,7 +190,7 @@ class View:
                     definition1 = view.definition
 
                     # Optimization, the view query **can** change if we re-run it,
-                    # but if it's not changed from the first iteration, we assume it wont.
+                    # but if it's not changed from the first iteration, we assume it won't.
                     if definition1 == compiled_definition:
                         return escape_params(compiled_definition)
 
@@ -317,7 +317,7 @@ class Views:
     one needs to either call `View.coerce_from_unknown(alembic_utils_view)` directly, or
     use `Views().are(...)` (which internally calls `coerce_from_unknown`).
 
-    Note: `ignore_views` option accepts a list of strings. Each string is individually
+    Note: `ignore` option accepts a list of strings. Each string is individually
         interpreted as a "glob". This means a string like "foo.*" would ignore all views
         contained within the schema "foo".
     """
@@ -325,6 +325,8 @@ class Views:
     views: list[View] = field(default_factory=list)
 
     ignore_unspecified: bool = False
+
+    ignore: Iterable[str] = field(default_factory=set)
     ignore_views: Iterable[str] = field(default_factory=set)
 
     @classmethod

--- a/src/sqlalchemy_declarative_extensions/view/compare.py
+++ b/src/sqlalchemy_declarative_extensions/view/compare.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+import warnings
+from dataclasses import dataclass, replace
 from fnmatch import fnmatch
 from typing import Union
 
@@ -54,6 +55,12 @@ def compare_views(
     metadata: MetaData,
     normalize_with_connection: bool = True,
 ) -> list[Operation]:
+    if views.ignore_views:
+        warnings.warn(
+            "`ignore_views` is deprecated, use `ignore` instead", DeprecationWarning
+        )
+        views = replace(views, ignore=list(views.ignore_views) + list(views.ignore))
+
     result: list[Operation] = []
 
     views_by_name = {r.qualified_name: r for r in views.views}
@@ -70,7 +77,7 @@ def compare_views(
         view_name = view.qualified_name
 
         ignore_matches = any(
-            fnmatch(view_name, view_pattern) for view_pattern in views.ignore_views
+            fnmatch(view_name, view_pattern) for view_pattern in views.ignore
         )
         if ignore_matches:
             continue
@@ -98,8 +105,7 @@ def compare_views(
     if not views.ignore_unspecified:
         for removed_view in removed_view_names:
             ignore_matches = any(
-                fnmatch(removed_view, view_pattern)
-                for view_pattern in views.ignore_views
+                fnmatch(removed_view, view_pattern) for view_pattern in views.ignore
             )
             if ignore_matches:
                 continue

--- a/tests/function/test_exclude.py
+++ b/tests/function/test_exclude.py
@@ -1,0 +1,61 @@
+import pytest
+from pytest_mock_resources import create_postgres_fixture
+from sqlalchemy import text
+from sqlalchemy.exc import ProgrammingError
+
+from sqlalchemy_declarative_extensions import (
+    Functions,
+    declarative_database,
+    register_sqlalchemy_events,
+)
+from sqlalchemy_declarative_extensions.sqlalchemy import declarative_base
+
+_Base = declarative_base()
+
+
+@declarative_database
+class Base(_Base):  # type: ignore
+    __abstract__ = True
+
+    functions = Functions(ignore=["foo.*", "p*"])
+
+
+register_sqlalchemy_events(Base.metadata, functions=True)
+
+pg = create_postgres_fixture(engine_kwargs={"echo": True}, session=True)
+
+
+def test_ignored(pg):
+    pg.execute(text("CREATE SCHEMA foo"))
+
+    # ignored by schema level exclusion
+    pg.execute(
+        text(
+            "CREATE FUNCTION foo.gimme() RETURNS INTEGER language sql as $$ select 1 $$;"
+        )
+    )
+
+    # ignored by name-level exclusion
+    pg.execute(
+        text(
+            "CREATE FUNCTION pignored() RETURNS INTEGER language sql as $$ select 1 $$;"
+        )
+    )
+
+    pg.execute(
+        text("CREATE FUNCTION kept() RETURNS INTEGER language sql as $$ select 1 $$;")
+    )
+
+    pg.commit()
+
+    Base.metadata.create_all(bind=pg.connection())
+    pg.commit()
+
+    result = pg.execute(text("SELECT foo.gimme()")).scalar()
+    assert result == 1
+
+    result = pg.execute(text("SELECT pignored()")).scalar()
+    assert result == 1
+
+    with pytest.raises(ProgrammingError):
+        pg.execute(text("SELECT gimme()")).scalar()

--- a/tests/view/test_ignore_glob.py
+++ b/tests/view/test_ignore_glob.py
@@ -19,7 +19,7 @@ class Base(_Base):  # type: ignore
     __abstract__ = True
 
     schemas = Schemas().are("foo", "bar", "ignoreme")
-    views = Views(ignore_views=["foo.*", "*.wat"])
+    views = Views(ignore=["foo.*"], ignore_views=["*.wat"])
 
 
 @view(Base, register_as_model=True)

--- a/tests/view/test_ignore_views.py
+++ b/tests/view/test_ignore_views.py
@@ -21,7 +21,7 @@ class Base(_Base):  # type: ignore
     __abstract__ = True
 
     schemas = Schemas().are("fooschema")
-    views = Views(ignore_views=["fooschema.bar", "moo"])
+    views = Views(ignore=["fooschema.bar", "moo"])
 
 
 class Foo(Base):


### PR DESCRIPTION
Fixes https://github.com/DanCardin/sqlalchemy-declarative-extensions/issues/52

Note this deprecates `Views.ignore_views` in favor of `Views.ignore` (for consistency among objects implementing the field.