### PR TITLE
fix: Ignore schema casing.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sqlalchemy-declarative-extensions"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Dan Cardin <ddcardin@gmail.com>"]
 
 description = "Library to declare additional kinds of objects not natively supported by SQLAlchemy/Alembic."

--- a/src/sqlalchemy_declarative_extensions/dialects/snowflake/query.py
+++ b/src/sqlalchemy_declarative_extensions/dialects/snowflake/query.py
@@ -10,7 +10,7 @@ def get_schemas_snowflake(connection: Connection):
     schemas_query = text(
         "SELECT schema_name"
         " FROM information_schema.schemata"
-        " WHERE schema_name NOT IN ('information_schema', 'pg_catalog', 'main')"
+        " WHERE lower(schema_name) NOT IN ('information_schema', 'pg_catalog', 'main')"
     )
 
     return {
@@ -22,7 +22,7 @@ def check_schema_exists_snowflake(connection: Connection, name: str) -> bool:
     schema_exists_query = text(
         "SELECT schema_name"
         " FROM information_schema.schemata"
-        " WHERE schema_name = :schema"
+        " WHERE lower(schema_name) = lower(:schema)"
     )
     row = connection.execute(schema_exists_query, {"schema": name}).scalar()
     return bool(row)


### PR DESCRIPTION
This helps to not need to declare INFORMATION_SCHEMA in order to avoid alembic attempting to autogenerate it. In particular, in testing we use fakesnow, which doesn't have perfect emulation (lowercase `information_schema`)