### PR TITLE
Make alembic a requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ python = ">=3.8,<4"
 sqlalchemy = ">=1.3"
 
 sqlglot = {version = "*", optional = true}
-alembic = { version = ">=1.0", optional = true }
+alembic = ">=1.0"
 
 [tool.poetry.group.dev.dependencies]
 alembic-utils = "0.8.1"


### PR DESCRIPTION
Due to the recent changes introduced in https://github.com/DanCardin/sqlalchemy-declarative-extensions/pull/95, it looks like alembic is now a requirement. Importing something like `from sqlalchemy_declarative_extensions import register_sqlalchemy_events` will now require alembic, which was not the case before.