### PR TITLE
fix: Strip whitespace from SQL def before asserting is SELECT

### DIFF
--- a/src/sqlalchemy_declarative_extensions/dialects/snowflake/query.py
+++ b/src/sqlalchemy_declarative_extensions/dialects/snowflake/query.py
@@ -84,7 +84,7 @@ def get_views_snowflake(connection: Connection):
 
         assert v.definition.startswith("CREATE VIEW")
         *_, definition = v.definition.split(" ", 4)
-        assert definition.startswith("SELECT")
+        assert definition.strip().startswith("SELECT")
 
         view = View(
             v.name,


### PR DESCRIPTION
I'm seeing a failure in `alembic revision --autogenerate` due to leading whitespace in `definition` prior to the beginning of the SQL statement, i.e.

```
(Pdb) definition.startswith("SELECT")
False
(Pdb) definition[0:50]
'           SELECT amazon_dsp.line_item_creative_lo'
(Pdb) definition.strip().startswith("SELECT")
True
```