### PR TITLE
fix: Snowflake - Stop asserting views start with SELECT (CTEs).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 0.15
 
+### 0.15.8
+
+- fix: Snowflake - Stop asserting views start with SELECT (CTEs).
+
+### 0.15.7
+
 - fix: Snowflake - Strip whitespace from SQL def before asserting starts with SELECT
 
 ### 0.15.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sqlalchemy-declarative-extensions"
-version = "0.15.7"
+version = "0.15.8"
 authors = [
     {name = "Dan Cardin", email = "ddcardin@gmail.com"},
 ]

--- a/src/sqlalchemy_declarative_extensions/dialects/snowflake/query.py
+++ b/src/sqlalchemy_declarative_extensions/dialects/snowflake/query.py
@@ -55,7 +55,7 @@ def get_roles_snowflake(connection: Connection, exclude=None):
 def get_databases_snowflake(connection: Connection):
     from sqlalchemy_declarative_extensions.database.base import Database
 
-    databases_query = text("SELECT database_name" " FROM information_schema.databases")
+    databases_query = text("SELECT database_name FROM information_schema.databases")
 
     return {
         database: Database(database)
@@ -84,7 +84,6 @@ def get_views_snowflake(connection: Connection):
 
         assert v.definition.startswith("CREATE VIEW")
         *_, definition = v.definition.split(" ", 4)
-        assert definition.strip().startswith("SELECT")
 
         view = View(
             v.name,


### PR DESCRIPTION
i believe that `assert` was more a guard against bugs in the code that processed the query, but taking into account WITH-starting queries, it just doesn't seem worth it to keep expanding the assert.

if there's some other definition structure that causes this to fail, we can address that more directly with better parsing.