### PR TITLE
Add REFERENCING OLD/NEW TABLE support for PG Triggers

### DIFF
--- a/src/sqlalchemy_declarative_extensions/dialects/postgresql/query.py
+++ b/src/sqlalchemy_declarative_extensions/dialects/postgresql/query.py
@@ -292,6 +292,8 @@ def get_triggers_postgresql(connection: Connection):
             for_each=TriggerForEach.from_bit_string(t.type),
             condition=condition,
             arguments=tuple(t.args) if t.args else None,
+            old_table=t.old_table,
+            new_table=t.new_table,
         )
         triggers.append(trigger)
 

--- a/src/sqlalchemy_declarative_extensions/dialects/postgresql/schema.py
+++ b/src/sqlalchemy_declarative_extensions/dialects/postgresql/schema.py
@@ -137,6 +137,8 @@ pg_trigger = table(
     column("tgargs"),
     column("tgqual"),
     column("tgisinternal"),
+    column("tgoldtable"),
+    column("tgnewtable"),
 )
 
 pg_type = table(
@@ -396,6 +398,8 @@ triggers_query = (
         rel_nsp.c.nspname.label("on_schema"),
         pg_proc.c.proname.label("execute_name"),
         proc_nsp.c.nspname.label("execute_schema"),
+        pg_trigger.c.tgoldtable.label("old_table"),
+        pg_trigger.c.tgnewtable.label("new_table"),
     )
     .select_from(
         pg_trigger.join(pg_class, pg_trigger.c.tgrelid == pg_class.c.oid)

--- a/src/sqlalchemy_declarative_extensions/dialects/postgresql/trigger.py
+++ b/src/sqlalchemy_declarative_extensions/dialects/postgresql/trigger.py
@@ -91,6 +91,8 @@ class Trigger(base.Trigger):
     for_each: TriggerForEach = TriggerForEach.statement
     condition: str | None = None
     arguments: tuple[str, ...] | None = None
+    old_table: str | None = None
+    new_table: str | None = None
 
     @classmethod
     def before(
@@ -125,6 +127,12 @@ class Trigger(base.Trigger):
             execute=execute,
             name=name,
         )
+
+    def referencing_old_table_as(self, table_name: str):
+        return replace(self, old_table=table_name)
+
+    def referencing_new_table_as(self, table_name: str):
+        return replace(self, new_table=table_name)
 
     def for_each_row(self):
         return replace(self, for_each=TriggerForEach.row)
@@ -162,6 +170,13 @@ class Trigger(base.Trigger):
         components.append("ON")
 
         components.append(quote_name(self.on))
+
+        if self.old_table or self.new_table:
+            components.append("REFERENCING")
+            if self.old_table:
+                components.append(f"OLD TABLE AS {quote_name(self.old_table)}")
+            if self.new_table:
+                components.append(f"NEW TABLE AS {quote_name(self.new_table)}")
 
         components.append("FOR EACH")
         components.append(self.for_each.value)

--- a/tests/trigger/test_for_each_statement_postgres.py
+++ b/tests/trigger/test_for_each_statement_postgres.py
@@ -1,0 +1,89 @@
+from pytest_mock_resources import create_postgres_fixture
+from sqlalchemy import Column, text, types
+
+from sqlalchemy_declarative_extensions import (
+    Triggers,
+    declarative_database,
+    register_sqlalchemy_events,
+)
+from sqlalchemy_declarative_extensions.dialects.postgresql import Trigger
+from sqlalchemy_declarative_extensions.sqlalchemy import declarative_base
+from sqlalchemy_declarative_extensions.trigger.compare import compare_triggers
+
+_Base = declarative_base()
+
+
+@declarative_database
+class Base(_Base):  # type: ignore
+    __abstract__ = True
+
+    triggers = Triggers().are(
+        Trigger.after("update", on="foo", execute="gimme")
+        .named("on_insert_foo")
+        .when("pg_trigger_depth() < 1")
+        .for_each_statement()
+        .referencing_old_table_as("old_foo")
+        .referencing_new_table_as("new_foo")
+        .with_arguments("declarative!"),
+    )
+
+
+class Foo(Base):
+    __tablename__ = "foo"
+
+    id = Column(types.Integer(), primary_key=True)
+    extra = Column(types.String(), nullable=True)
+
+
+register_sqlalchemy_events(Base.metadata, triggers=True)
+
+pg = create_postgres_fixture(engine_kwargs={"echo": True}, session=True)
+
+
+def test_update(pg):
+    pg.execute(text("CREATE TABLE foo (id integer primary key, extra text);"))
+    pg.execute(
+        text(
+            """
+            CREATE FUNCTION gimme() RETURNS trigger LANGUAGE plpgsql AS $$
+            BEGIN
+            -- Read the extra from TG_ARGV
+            INSERT INTO foo (id, extra) SELECT new_foo.id + 1, TG_ARGV[0] FROM new_foo;
+            RETURN NULL;
+            END
+            $$;
+            """
+        )
+    )
+    pg.execute(
+        text(
+            "CREATE TRIGGER on_insert_foo AFTER INSERT ON foo REFERENCING NEW TABLE AS new_foo FOR EACH STATEMENT "
+            "WHEN (pg_trigger_depth() < 1) EXECUTE PROCEDURE gimme();"
+        )
+    )
+    pg.commit()
+
+    pg.add(Foo(id=5))
+    pg.commit()
+
+    result = [(r.id, r.extra) for r in pg.query(Foo).all()]
+    assert result == [(5, None), (6, None)]
+
+    Base.metadata.create_all(bind=pg.connection())
+    pg.commit()
+
+    foo = Foo(id=9)
+    pg.add(foo)
+    pg.commit()
+
+    result = [(r.id, r.extra) for r in pg.query(Foo).all()]
+    assert result == [(5, None), (6, None), (9, None)]
+
+    foo.id = 10
+    pg.commit()
+    result = [(r.id, r.extra) for r in pg.query(Foo).all()]
+    assert result == [(5, None), (6, None), (10, None), (11, "declarative!")]
+
+    connection = pg.connection()
+    diff = compare_triggers(connection, Base.metadata.info["triggers"])
+    assert diff == []


### PR DESCRIPTION
This PR adds support for specifying `REFERENCING OLD/NEW TABLE AS ...` clauses for Postgres triggers. Example from the newly added test case:

``` python
Trigger.after("update", on="foo", execute="gimme")
.named("on_insert_foo")
.when("pg_trigger_depth() < 1")
.for_each_statement()
.referencing_old_table_as("old_foo")
.referencing_new_table_as("new_foo")
.with_arguments("declarative!"),
```

