### PR TITLE
Cast pg_proc char columns to Text explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.16
 
+### 0.16.2
+
+- fix: Cast pg_proc char columns to Text explicitly
+
 ### 0.16.1
 
 - fix: Use bind params regex from sqlalchemy while escaping colons.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sqlalchemy-declarative-extensions"
-version = "0.16.1"
+version = "0.16.2"
 authors = [
     {name = "Dan Cardin", email = "ddcardin@gmail.com"},
 ]

--- a/src/sqlalchemy_declarative_extensions/dialects/postgresql/schema.py
+++ b/src/sqlalchemy_declarative_extensions/dialects/postgresql/schema.py
@@ -4,8 +4,10 @@ from typing import TYPE_CHECKING, Collection
 
 from sqlalchemy import (
     String,
+    Text,
     and_,
     bindparam,
+    cast,
     column,
     exists,
     func,
@@ -352,9 +354,9 @@ functions_query = (
         pg_type.c.typname.label("base_return_type"),
         pg_proc.c.prosrc.label("source"),
         pg_proc.c.prosecdef.label("security_definer"),
-        pg_proc.c.prokind.label("kind"),
+        cast(pg_proc.c.prokind, Text).label("kind"),
         func.pg_get_function_arguments(pg_proc.c.oid).label("parameters"),
-        pg_proc.c.provolatile.label("volatility"),
+        cast(pg_proc.c.provolatile, Text).label("volatility"),
         func.pg_get_function_result(pg_proc.c.oid).label("return_type_string"),
         pg_proc.c.proargnames.label("arg_names"),
         pg_proc.c.proargmodes.label("arg_modes"),


### PR DESCRIPTION
Fixes #125 

Seems like `char` columns can be wrapped as `bytes` values under certain circumstances. See https://github.com/DanCardin/sqlalchemy-declarative-extensions/issues/125