### PR TITLE
Fix PostgreSQL function argument default parsing

### DIFF
--- a/tests/dialect/postgresql/test_function_defaults.py
+++ b/tests/dialect/postgresql/test_function_defaults.py
@@ -13,9 +13,6 @@ from sqlalchemy_declarative_extensions.function.compare import compare_functions
 pg = create_postgres_fixture(scope="function", engine_kwargs={"echo": True})
 
 
-@pytest.fixture
-def pmr_postgres_config():
-    return PostgresConfig(image="postgres:11", port=None, ci_port=None)
 
 
 @pytest.mark.parametrize(

--- a/tests/dialect/postgresql/test_function_defaults.py
+++ b/tests/dialect/postgresql/test_function_defaults.py
@@ -1,0 +1,48 @@
+import pytest
+from pytest_mock_resources import PostgresConfig, create_postgres_fixture
+from sqlalchemy import text
+
+from sqlalchemy_declarative_extensions import Functions
+from sqlalchemy_declarative_extensions.dialects.postgresql import (
+    Function,
+    FunctionParam,
+    FunctionVolatility,
+)
+from sqlalchemy_declarative_extensions.function.compare import compare_functions
+
+pg = create_postgres_fixture(scope="function", engine_kwargs={"echo": True})
+
+
+@pytest.fixture
+def pmr_postgres_config():
+    return PostgresConfig(image="postgres:11", port=None, ci_port=None)
+
+
+@pytest.mark.parametrize(
+    ("default_a", "default_b", "default_c"),
+    [(None, None, "''::text"), (1, 0, "'m'::text"), (None, 2, "'ft'::text")],
+)
+def test_function_argument_defaults(pg, default_a, default_b, default_c):
+    add_label_function = Function(
+        name="add_label",
+        definition="""
+            BEGIN
+                RETURN (((a + b))::text || c);
+            END;
+        """,
+        parameters=[
+            FunctionParam("a", "integer", default=default_a),
+            FunctionParam("b", "integer", default=default_b),
+            FunctionParam("c", "text", default=default_c),
+        ],
+        returns="TEXT",
+        volatility=FunctionVolatility.STABLE,
+        language="plpgsql",
+    ).normalize()
+    create_function = add_label_function.to_sql_create()
+    functions = Functions([add_label_function])
+    with pg.connect() as connection:
+        connection.execute(text("\n".join(create_function)))
+        diff = compare_functions(connection, functions)
+    for op in diff:
+        assert op.from_function == op.function


### PR DESCRIPTION
### Problem
When parsing PostgreSQL function defaults, `pg_proc.proargdefaults` converted with `pg_get_expr()` returns a single comma-separated string containing all default values, rather than an array.

This creates several challenges:
1. The default values need to be split from the comma-separated string
2. These values must then be aligned to the rightmost input arguments (since only trailing arguments can have defaults in PostgreSQL)
3. Edge cases exist where commas might legitimately appear within default values themselves, making naive string splitting unreliable

### Solution
Instead of parsing and realigning the comma-separated string, this PR uses PostgreSQL's `pg_get_function_arg_default()` function to retrieve the default value for each argument individually. This function:
- Takes an argument position and returns the default for that specific argument
- Returns the properly formatted default expression
- Avoids any ambiguity around parsing comma-separated values
- Eliminates the need for complex right-alignment logic